### PR TITLE
feat: add content layer, sticky header, and hero section

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -25,13 +25,13 @@
      on the reference site via data-framer-appear-id, though its exact
      runtime timing isn't recoverable from static CSS, so this duration/
      easing is a tasteful approximation, not a measured value. */
-  --animate-fade-in-up: fade-in-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+  --animate-fade-in-up: fade-in-up 0.9s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
 @keyframes fade-in-up {
   from {
     opacity: 0;
-    transform: translateY(16px);
+    transform: translateY(32px);
   }
   to {
     opacity: 1;

--- a/app/globals.css
+++ b/app/globals.css
@@ -15,10 +15,11 @@
   --font-sans: var(--font-inter);
   --font-mono: var(--font-jetbrains-mono);
 
-  /* Mobile and tablet share one collapsed layout through 768px inclusive —
-     shift the default `md` breakpoint (768px) up by 1px so `md:` utilities
-     only apply above it, matching the design spec's "<=768px" rule. */
-  --breakpoint-md: 769px;
+  /* Mobile and tablet share one collapsed nav/layout; measured directly
+     against the live reference site via binary search (collapsed at
+     959px, expanded at 960px) — supersedes the spec doc's "768px" claim,
+     which didn't hold up against the actual site. */
+  --breakpoint-md: 960px;
 }
 
 @layer base {

--- a/app/globals.css
+++ b/app/globals.css
@@ -14,6 +14,11 @@
 
   --font-sans: var(--font-inter);
   --font-mono: var(--font-jetbrains-mono);
+
+  /* Mobile and tablet share one collapsed layout through 768px inclusive —
+     shift the default `md` breakpoint (768px) up by 1px so `md:` utilities
+     only apply above it, matching the design spec's "<=768px" rule. */
+  --breakpoint-md: 769px;
 }
 
 @layer base {

--- a/app/globals.css
+++ b/app/globals.css
@@ -20,6 +20,23 @@
      959px, expanded at 960px) — supersedes the spec doc's "768px" claim,
      which didn't hold up against the actual site. */
   --breakpoint-md: 960px;
+
+  /* On-load entry animation for above-the-fold content — confirmed present
+     on the reference site via data-framer-appear-id, though its exact
+     runtime timing isn't recoverable from static CSS, so this duration/
+     easing is a tasteful approximation, not a measured value. */
+  --animate-fade-in-up: fade-in-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @layer base {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ export default function Home() {
   return (
     <>
       <Header />
-      <main id="main" className="flex-1">
+      <main id="main" className="flex flex-1 flex-col">
         <Hero />
       </main>
     </>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,13 @@
+import { Header } from "@/components/Header/Header";
+import { Hero } from "@/components/Hero/Hero";
+
 export default function Home() {
   return (
-    <main className="flex flex-1 items-center justify-center px-12">
-      <p className="font-mono text-sm uppercase tracking-widest text-muted-3">
-        Scaffold OK — <span className="text-accent">● available</span>
-      </p>
-    </main>
+    <>
+      <Header />
+      <main id="main" className="flex-1">
+        <Hero />
+      </main>
+    </>
   );
 }

--- a/components/Container.tsx
+++ b/components/Container.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+interface ContainerProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function Container({ children, className = "" }: ContainerProps) {
+  return (
+    <div className={`mx-auto w-full max-w-[1408px] px-6 md:px-16 ${className}`}>
+      {children}
+    </div>
+  );
+}

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Container } from "@/components/Container";
 import { Nav } from "./Nav";
 
 export function Header() {
@@ -10,7 +11,7 @@ export function Header() {
       >
         Skip to content
       </a>
-      <div className="mx-auto flex max-w-[1200px] items-center gap-6 px-6 py-6 md:px-16">
+      <Container className="flex items-center gap-6 py-6">
         <Link
           href="/"
           className="shrink-0 font-sans text-sm font-bold text-white"
@@ -20,7 +21,7 @@ export function Header() {
         </Link>
         <span aria-hidden="true" className="h-px flex-1 bg-border-1" />
         <Nav />
-      </div>
+      </Container>
     </header>
   );
 }

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -10,10 +10,10 @@ export function Header() {
       >
         Skip to content
       </a>
-      <div className="flex items-center gap-6 px-6 py-6 md:px-12">
+      <div className="mx-auto flex max-w-[1200px] items-center gap-6 px-6 py-6 md:px-16">
         <Link
           href="/"
-          className="shrink-0 font-sans text-sm font-medium text-white"
+          className="shrink-0 font-sans text-base font-bold text-white"
         >
           <span className="md:hidden">DM</span>
           <span className="hidden md:inline">Daine Mawer</span>

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import { Nav } from "./Nav";
+
+export function Header() {
+  return (
+    <header className="sticky top-0 z-50 bg-bg">
+      <a
+        href="#main"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[60] focus:rounded focus:bg-white focus:px-4 focus:py-2 focus:text-bg"
+      >
+        Skip to content
+      </a>
+      <div className="flex items-center gap-6 px-6 py-6 md:px-12">
+        <Link
+          href="/"
+          className="shrink-0 font-sans text-sm font-medium text-white"
+        >
+          <span className="md:hidden">DM</span>
+          <span className="hidden md:inline">Daine Mawer</span>
+        </Link>
+        <span aria-hidden="true" className="h-px flex-1 bg-border-1" />
+        <Nav />
+      </div>
+    </header>
+  );
+}

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -13,7 +13,7 @@ export function Header() {
       <div className="mx-auto flex max-w-[1200px] items-center gap-6 px-6 py-6 md:px-16">
         <Link
           href="/"
-          className="shrink-0 font-sans text-base font-bold text-white"
+          className="shrink-0 font-sans text-sm font-bold text-white"
         >
           <span className="md:hidden">DM</span>
           <span className="hidden md:inline">Daine Mawer</span>

--- a/components/Header/Nav.tsx
+++ b/components/Header/Nav.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { motion } from "motion/react";
+import { useRef, useState } from "react";
+import { NavLink } from "./NavLink";
+
+const PRIMARY_LINKS = [
+  { label: "Work", href: "#work" },
+  { label: "About", href: "#about" },
+  { label: "Blog", href: "/blog" },
+];
+
+const CONTACT_LINK = { label: "Contact", href: "#contact" };
+
+interface PillRect {
+  left: number;
+  width: number;
+}
+
+export function Nav() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [pill, setPill] = useState<PillRect | null>(null);
+
+  function handleEnter(event: React.MouseEvent<HTMLAnchorElement>) {
+    const containerRect = containerRef.current?.getBoundingClientRect();
+    if (!containerRect) return;
+    const linkRect = event.currentTarget.getBoundingClientRect();
+    setPill({
+      left: linkRect.left - containerRect.left,
+      width: linkRect.width,
+    });
+  }
+
+  return (
+    <nav
+      ref={containerRef}
+      onMouseLeave={() => setPill(null)}
+      className="relative flex items-center"
+    >
+      {pill ? (
+        <motion.div
+          className="absolute inset-y-0 rounded-full bg-white/10"
+          initial={false}
+          animate={{ left: pill.left, width: pill.width }}
+          transition={{ type: "spring", stiffness: 400, damping: 35 }}
+        />
+      ) : null}
+      <div className="hidden items-center md:flex">
+        {PRIMARY_LINKS.map((link) => (
+          <NavLink key={link.href} href={link.href} onMouseEnter={handleEnter}>
+            {link.label}
+          </NavLink>
+        ))}
+      </div>
+      <NavLink href={CONTACT_LINK.href} onMouseEnter={handleEnter}>
+        {CONTACT_LINK.label}
+      </NavLink>
+    </nav>
+  );
+}

--- a/components/Header/Nav.tsx
+++ b/components/Header/Nav.tsx
@@ -1,7 +1,3 @@
-"use client";
-
-import { motion } from "motion/react";
-import { useRef, useState } from "react";
 import { NavLink } from "./NavLink";
 
 const PRIMARY_LINKS = [
@@ -12,49 +8,17 @@ const PRIMARY_LINKS = [
 
 const CONTACT_LINK = { label: "Contact", href: "#contact" };
 
-interface PillRect {
-  left: number;
-  width: number;
-}
-
 export function Nav() {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [pill, setPill] = useState<PillRect | null>(null);
-
-  function handleEnter(event: React.MouseEvent<HTMLAnchorElement>) {
-    const containerRect = containerRef.current?.getBoundingClientRect();
-    if (!containerRect) return;
-    const linkRect = event.currentTarget.getBoundingClientRect();
-    setPill({
-      left: linkRect.left - containerRect.left,
-      width: linkRect.width,
-    });
-  }
-
   return (
-    <nav
-      ref={containerRef}
-      onMouseLeave={() => setPill(null)}
-      className="relative flex items-center"
-    >
-      {pill ? (
-        <motion.div
-          className="absolute inset-y-0 rounded-full bg-white/10"
-          initial={false}
-          animate={{ left: pill.left, width: pill.width }}
-          transition={{ type: "spring", stiffness: 400, damping: 35 }}
-        />
-      ) : null}
+    <nav className="flex items-center">
       <div className="hidden items-center md:flex">
         {PRIMARY_LINKS.map((link) => (
-          <NavLink key={link.href} href={link.href} onMouseEnter={handleEnter}>
+          <NavLink key={link.href} href={link.href}>
             {link.label}
           </NavLink>
         ))}
       </div>
-      <NavLink href={CONTACT_LINK.href} onMouseEnter={handleEnter}>
-        {CONTACT_LINK.label}
-      </NavLink>
+      <NavLink href={CONTACT_LINK.href}>{CONTACT_LINK.label}</NavLink>
     </nav>
   );
 }

--- a/components/Header/NavLink.tsx
+++ b/components/Header/NavLink.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import type { MouseEventHandler } from "react";
+
+interface NavLinkProps {
+  href: string;
+  children: string;
+  onMouseEnter?: MouseEventHandler<HTMLAnchorElement>;
+}
+
+export function NavLink({ href, children, onMouseEnter }: NavLinkProps) {
+  return (
+    <Link
+      href={href}
+      onMouseEnter={onMouseEnter}
+      className="group relative block px-3 py-1.5 font-sans text-sm text-white/75 transition-colors hover:text-white"
+    >
+      <span className="relative block h-[1lh] overflow-hidden">
+        <span className="flex flex-col transition-transform duration-300 ease-out group-hover:-translate-y-[1lh]">
+          <span>{children}</span>
+          <span aria-hidden="true">{children}</span>
+          <span aria-hidden="true">{children}</span>
+        </span>
+      </span>
+    </Link>
+  );
+}

--- a/components/Header/NavLink.tsx
+++ b/components/Header/NavLink.tsx
@@ -1,17 +1,14 @@
 import Link from "next/link";
-import type { MouseEventHandler } from "react";
 
 interface NavLinkProps {
   href: string;
   children: string;
-  onMouseEnter?: MouseEventHandler<HTMLAnchorElement>;
 }
 
-export function NavLink({ href, children, onMouseEnter }: NavLinkProps) {
+export function NavLink({ href, children }: NavLinkProps) {
   return (
     <Link
       href={href}
-      onMouseEnter={onMouseEnter}
       className="group relative block px-3 py-1.5 font-sans text-sm text-white/75 transition-colors hover:text-white"
     >
       <span className="relative block h-[1lh] overflow-hidden">

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -1,10 +1,10 @@
 export function Hero() {
   return (
-    <section className="px-6 py-24 md:px-12 md:py-32">
+    <section className="mx-auto flex w-full max-w-[1200px] flex-1 flex-col justify-between px-6 py-10 md:px-16 md:py-16">
       <div className="flex items-center gap-4">
         <div
           aria-hidden="true"
-          className="h-12 w-12 shrink-0 rounded-full bg-surface-2 ring-1 ring-border-1"
+          className="h-9 w-9 shrink-0 rounded-full bg-surface-2 ring-1 ring-border-1 md:h-16 md:w-16"
         />
         <p className="font-mono text-xs text-muted-2 sm:text-sm">
           I build and ship AI-powered products using Next.js, TypeScript,
@@ -12,11 +12,11 @@ export function Hero() {
         </p>
       </div>
 
-      <h1 className="mt-8 max-w-4xl text-[40px] font-semibold leading-[1.1] tracking-[-1.5px] text-white sm:text-[56px] sm:tracking-[-2.5px] md:text-[80px] md:leading-[84px] md:tracking-[-4px]">
+      <h1 className="max-w-4xl text-[44px] font-semibold leading-[1.05] tracking-[-2.2px] text-white md:text-[80px] md:leading-[84px] md:tracking-[-4px] min-[1440px]:text-[104px] min-[1440px]:leading-[109px] min-[1440px]:tracking-[-5.2px]">
         Staff Engineer, <span className="text-white/50">Building with AI</span>
       </h1>
 
-      <div className="mt-10 flex flex-col divide-y divide-border-1 font-mono text-xs uppercase tracking-widest text-muted-3 md:flex-row md:items-center md:divide-x md:divide-y-0">
+      <div className="flex flex-col divide-y divide-border-1 font-mono text-xs uppercase tracking-widest text-muted-3 md:flex-row md:items-center md:divide-x md:divide-y-0">
         <span className="py-2 md:py-0 md:pr-4">Cape Town, South Africa</span>
         <span className="py-2 md:px-4">GMT+2</span>
         <span className="flex items-center gap-2 py-2 text-accent md:pl-4">

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -1,25 +1,33 @@
 export function Hero() {
   return (
-    <section className="mx-auto flex w-full max-w-[1200px] flex-1 flex-col justify-between px-6 py-10 md:px-16 md:py-16">
+    <section className="mx-auto w-full max-w-[1200px] px-6 py-10 md:px-16 md:py-16">
       <div className="flex items-center gap-4">
         <div
           aria-hidden="true"
           className="h-9 w-9 shrink-0 rounded-full bg-surface-2 ring-1 ring-border-1 md:h-16 md:w-16"
         />
-        <p className="font-mono text-xs text-muted-2 sm:text-sm">
+        <p className="max-w-[370px] font-mono text-xs text-muted-2 sm:text-sm">
           I build and ship AI-powered products using Next.js, TypeScript,
           Supabase, Vercel, and Expo
         </p>
       </div>
 
-      <h1 className="max-w-4xl text-[44px] font-semibold leading-[1.05] tracking-[-2.2px] text-white md:text-[80px] md:leading-[84px] md:tracking-[-4px] min-[1440px]:text-[104px] min-[1440px]:leading-[109px] min-[1440px]:tracking-[-5.2px]">
+      <h1 className="mt-10 max-w-4xl text-[44px] font-semibold leading-[1.05] tracking-[-2.2px] text-white md:mt-24 md:text-[80px] md:leading-[84px] md:tracking-[-4px] min-[1440px]:text-[104px] min-[1440px]:leading-[109px] min-[1440px]:tracking-[-5.2px]">
         Staff Engineer, <span className="text-white/50">Building with AI</span>
       </h1>
 
-      <div className="flex flex-col divide-y divide-border-1 font-mono text-xs uppercase tracking-widest text-muted-3 md:flex-row md:items-center md:divide-x md:divide-y-0">
-        <span className="py-2 md:py-0 md:pr-4">Cape Town, South Africa</span>
-        <span className="py-2 md:px-4">GMT+2</span>
-        <span className="flex items-center gap-2 py-2 text-accent md:pl-4">
+      <div className="mt-6 flex flex-col gap-2 font-mono text-xs uppercase tracking-widest text-muted-3 md:mt-12 md:flex-row md:items-center md:gap-4">
+        <span>Cape Town, South Africa</span>
+        <span
+          aria-hidden="true"
+          className="h-px w-full bg-white/10 md:w-auto md:flex-1"
+        />
+        <span>GMT+2</span>
+        <span
+          aria-hidden="true"
+          className="h-px w-full bg-white/10 md:w-auto md:flex-1"
+        />
+        <span className="flex items-center gap-2 text-accent">
           <span
             aria-hidden="true"
             className="h-1.5 w-1.5 rounded-full bg-accent"

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -1,40 +1,45 @@
+import { Container } from "@/components/Container";
+
 export function Hero() {
   return (
-    <section className="mx-auto w-full max-w-[1200px] px-6 py-10 md:px-16 md:py-16">
-      <div className="flex items-center gap-4">
-        <div
-          aria-hidden="true"
-          className="h-9 w-9 shrink-0 rounded-full bg-surface-2 ring-1 ring-border-1 md:h-16 md:w-16"
-        />
-        <p className="max-w-[370px] font-mono text-xs text-muted-2 sm:text-sm">
-          I build and ship AI-powered products using Next.js, TypeScript,
-          Supabase, Vercel, and Expo
-        </p>
-      </div>
+    <section>
+      <Container className="py-10 md:py-16">
+        <div className="flex animate-fade-in-up items-center gap-4">
+          <div
+            aria-hidden="true"
+            className="h-9 w-9 shrink-0 rounded-full bg-surface-2 ring-1 ring-border-1 md:h-16 md:w-16"
+          />
+          <p className="max-w-[370px] font-mono text-xs text-muted-2 sm:text-sm">
+            I build and ship AI-powered products using Next.js, TypeScript,
+            Supabase, Vercel, and Expo
+          </p>
+        </div>
 
-      <h1 className="mt-10 max-w-4xl text-[44px] font-semibold leading-[1.05] tracking-[-2.2px] text-white md:mt-24 md:text-[80px] md:leading-[84px] md:tracking-[-4px] min-[1440px]:text-[104px] min-[1440px]:leading-[109px] min-[1440px]:tracking-[-5.2px]">
-        Staff Engineer, <span className="text-white/50">Building with AI</span>
-      </h1>
+        <h1 className="mt-16 max-w-4xl animate-fade-in-up text-[44px] font-semibold leading-[1.05] tracking-[-2.2px] text-white [animation-delay:100ms] md:mt-[195px] md:text-[80px] md:leading-[84px] md:tracking-[-4px] min-[1440px]:text-[104px] min-[1440px]:leading-[109px] min-[1440px]:tracking-[-5.2px]">
+          Staff Engineer,{" "}
+          <span className="text-white/50">Building with AI</span>
+        </h1>
 
-      <div className="mt-6 flex flex-col gap-2 font-mono text-xs uppercase tracking-widest text-muted-3 md:mt-12 md:flex-row md:items-center md:gap-4">
-        <span>Cape Town, South Africa</span>
-        <span
-          aria-hidden="true"
-          className="h-px w-full bg-white/10 md:w-auto md:flex-1"
-        />
-        <span>GMT+2</span>
-        <span
-          aria-hidden="true"
-          className="h-px w-full bg-white/10 md:w-auto md:flex-1"
-        />
-        <span className="flex items-center gap-2 text-accent">
+        <div className="mt-6 flex animate-fade-in-up flex-col gap-2 font-mono text-xs uppercase tracking-widest text-muted-3 [animation-delay:200ms] md:mt-12 md:flex-row md:items-center md:gap-4">
+          <span>Cape Town, South Africa</span>
           <span
             aria-hidden="true"
-            className="h-1.5 w-1.5 rounded-full bg-accent"
+            className="h-px w-full bg-white/10 md:w-auto md:flex-1"
           />
-          Available
-        </span>
-      </div>
+          <span>GMT+2</span>
+          <span
+            aria-hidden="true"
+            className="h-px w-full bg-white/10 md:w-auto md:flex-1"
+          />
+          <span className="flex items-center gap-2 text-accent">
+            <span
+              aria-hidden="true"
+              className="h-1.5 w-1.5 rounded-full bg-accent"
+            />
+            Available
+          </span>
+        </div>
+      </Container>
     </section>
   );
 }

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -1,0 +1,32 @@
+export function Hero() {
+  return (
+    <section className="px-6 py-24 md:px-12 md:py-32">
+      <div className="flex items-center gap-4">
+        <div
+          aria-hidden="true"
+          className="h-12 w-12 shrink-0 rounded-full bg-surface-2 ring-1 ring-border-1"
+        />
+        <p className="font-mono text-xs text-muted-2 sm:text-sm">
+          I build and ship AI-powered products using Next.js, TypeScript,
+          Supabase, Vercel, and Expo
+        </p>
+      </div>
+
+      <h1 className="mt-8 max-w-4xl text-[40px] font-semibold leading-[1.1] tracking-[-1.5px] text-white sm:text-[56px] sm:tracking-[-2.5px] md:text-[80px] md:leading-[84px] md:tracking-[-4px]">
+        Staff Engineer, <span className="text-white/50">Building with AI</span>
+      </h1>
+
+      <div className="mt-10 flex flex-col divide-y divide-border-1 font-mono text-xs uppercase tracking-widest text-muted-3 md:flex-row md:items-center md:divide-x md:divide-y-0">
+        <span className="py-2 md:py-0 md:pr-4">Cape Town, South Africa</span>
+        <span className="py-2 md:px-4">GMT+2</span>
+        <span className="flex items-center gap-2 py-2 text-accent md:pl-4">
+          <span
+            aria-hidden="true"
+            className="h-1.5 w-1.5 rounded-full bg-accent"
+          />
+          Available
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/lib/content/experience.ts
+++ b/lib/content/experience.ts
@@ -1,0 +1,28 @@
+export interface ExperienceEntry {
+  company: string;
+  title: string;
+  dateRange: string;
+}
+
+export const experience: ExperienceEntry[] = [
+  {
+    company: "Fueled",
+    title: "Staff Engineer, Web Applications",
+    dateRange: "Feb 2026 → Now",
+  },
+  {
+    company: "10up",
+    title: "Staff Frontend Engineer, EMEA",
+    dateRange: "Sep 2017 → Feb 2026",
+  },
+  {
+    company: "24.com",
+    title: "Lead Frontend Engineer",
+    dateRange: "May 2016 → Oct 2017",
+  },
+  {
+    company: "Self Employed",
+    title: "Frontend Developer (Freelance)",
+    dateRange: "Jan 2009 → May 2016",
+  },
+];

--- a/lib/content/projects.ts
+++ b/lib/content/projects.ts
@@ -1,0 +1,118 @@
+export interface Project {
+  slug: string;
+  title: string;
+  year: number;
+  tags: string[];
+  description: string;
+  url: string;
+  client: string;
+  timeframe: string;
+  problem: string;
+  solution: string;
+  gallery: { label: string }[];
+}
+
+export const projects: Project[] = [
+  {
+    slug: "monocle",
+    title: "Monocle",
+    year: 2025,
+    tags: ["Full Stack", "Redesign"],
+    description: "Complete redesign and rebuild of Monocle's platform.",
+    url: "https://monocle.com",
+    client: "Monocle",
+    timeframe: "3 months",
+    problem:
+      "Monocle's existing platform was built on a legacy stack that couldn't keep pace with editorial demands — page loads were slow, the CMS made publishing painful, and the design no longer reflected the brand.",
+    solution:
+      "Rebuilt the platform end-to-end on Next.js with a modern headless CMS, cutting load times significantly and giving the editorial team a publishing workflow that matches how they actually work. Design and engineering were handled together to ship a cohesive, fast, on-brand experience.",
+    gallery: [
+      { label: "Homepage" },
+      { label: "Article Page" },
+      { label: "Mobile Breakpoints" },
+    ],
+  },
+  {
+    slug: "ayala-land-hospitality",
+    title: "Ayala Land Hospitality",
+    year: 2025,
+    tags: ["Next.js", "Sanity"],
+    description:
+      "Multi-brand hotel booking platform across Ayala Land's hospitality group.",
+    url: "https://example.com/work/ayala-land-hospitality",
+    client: "Ayala Land Hospitality",
+    timeframe: "4 months",
+    problem:
+      "Ayala Land's hospitality group spans multiple hotel brands, each previously running on its own disconnected booking system — inconsistent UX, duplicated engineering effort, and no shared component library.",
+    solution:
+      "Designed and built a single Next.js platform with Sanity-managed content that powers every brand from one codebase, with brand-specific theming and a unified booking flow. Cut time-to-launch for new properties from months to weeks.",
+    gallery: [
+      { label: "Homepage" },
+      { label: "Booking Flow" },
+      { label: "Mobile Breakpoints" },
+    ],
+  },
+  {
+    slug: "hello-magazine",
+    title: "Hello Magazine",
+    year: 2023,
+    tags: ["Next.js", "Headless CMS"],
+    description:
+      "Editorial platform rebuild for one of the world's largest celebrity/lifestyle publishers.",
+    url: "https://example.com/work/hello-magazine",
+    client: "Hello Magazine",
+    timeframe: "5 months",
+    problem:
+      "One of the world's largest celebrity and lifestyle publishers needed to move off a legacy CMS that couldn't handle their publishing volume or editorial ambitions.",
+    solution:
+      "Rebuilt the editorial platform on Next.js with a headless CMS, giving editors a faster publishing workflow and readers a significantly faster site, without interrupting the newsroom's day-to-day output during the migration.",
+    gallery: [
+      { label: "Homepage" },
+      { label: "Article Page" },
+      { label: "Mobile Breakpoints" },
+    ],
+  },
+  {
+    slug: "boston-com",
+    title: "Boston.com",
+    year: 2022,
+    tags: ["Rebuild", "Performance"],
+    description:
+      "Full platform rebuild for one of the US's oldest news mastheads.",
+    url: "https://example.com/work/boston-com",
+    client: "Boston.com",
+    timeframe: "6 months",
+    problem:
+      "One of the US's oldest news mastheads was running on an aging platform that struggled under traffic spikes and dragged down Core Web Vitals, hurting both readers and ad revenue.",
+    solution:
+      'Led a full platform rebuild focused on performance — restructuring rendering strategy, trimming bundle size, and rearchitecting the ad-loading pipeline — bringing the site comfortably within "Good" Core Web Vitals thresholds at scale.',
+    gallery: [
+      { label: "Homepage" },
+      { label: "Article Page" },
+      { label: "Mobile Breakpoints" },
+    ],
+  },
+  {
+    slug: "nobel-peace-prize",
+    title: "Nobel Peace Prize",
+    year: 2020,
+    tags: ["Rebuild"],
+    description: "Rebuild of the official Nobel Peace Prize website.",
+    url: "https://example.com/work/nobel-peace-prize",
+    client: "The Nobel Peace Prize",
+    timeframe: "3 months",
+    problem:
+      "The official Nobel Peace Prize website needed a rebuild that could honor the gravity of the institution while being maintainable by a small editorial team.",
+    solution:
+      "Rebuilt the site with a clean, accessible, content-first design and a CMS-driven structure that lets the Nobel team publish laureate and ceremony content independently, without engineering support.",
+    gallery: [
+      { label: "Homepage" },
+      { label: "Laureate Page" },
+      { label: "Mobile Breakpoints" },
+    ],
+  },
+];
+
+export function getProject(slug: string): Project | undefined {
+  return projects.find((project) => project.slug === slug);
+}

--- a/lib/content/services.ts
+++ b/lib/content/services.ts
@@ -1,0 +1,50 @@
+export interface Service {
+  index: string;
+  title: string;
+  stack: string[];
+  pitch: string;
+  engagement: "Project" | "Sprint" | "Retainer";
+}
+
+export const services: Service[] = [
+  {
+    index: "01",
+    title: "Custom Software & MVP Development",
+    stack: ["Next.js", "TypeScript", "Supabase"],
+    pitch:
+      "Turn your idea into production-ready software in weeks, not months — a full-stack build tailored to your business, not a template.",
+    engagement: "Project",
+  },
+  {
+    index: "02",
+    title: "AI Agents & Automation",
+    stack: ["OpenAI", "Vercel AI SDK"],
+    pitch:
+      "I design and build AI agents that handle real workflows — support, ops, internal tooling — so your team stops doing it by hand.",
+    engagement: "Sprint",
+  },
+  {
+    index: "03",
+    title: "Performance & Cost Optimization",
+    stack: ["Core Web Vitals", "Lighthouse CI"],
+    pitch:
+      "Slow and expensive to run? I audit and rebuild for speed and lower infra cost — 40% faster loads, 30% smaller bundles, proven at enterprise scale.",
+    engagement: "Sprint",
+  },
+  {
+    index: "04",
+    title: "Legacy Modernization & Migration",
+    stack: ["Next.js", "TypeScript"],
+    pitch:
+      "Move off an outdated stack onto a modern, maintainable foundation — without paying for a rebuild from scratch.",
+    engagement: "Project",
+  },
+  {
+    index: "05",
+    title: "Fractional Staff Engineering",
+    stack: ["Architecture", "Mentorship"],
+    pitch:
+      "Embedded, staff-level technical leadership for teams that need senior direction without a full-time hire.",
+    engagement: "Retainer",
+  },
+];


### PR DESCRIPTION
## Summary

Builds the first section of the Quattro-inspired homepage: the typed content layer, sticky header/nav, and hero. Verified extensively against the live reference site (quattro.framer.website) rather than relying solely on the written design spec, which had several inaccuracies.

## Type of change

- [x] feat — new feature

## Changes

- `lib/content/{projects,experience,services}.ts`: typed data for the Work, Experience, and Services sections (not yet rendered, prepping for follow-up PRs)
- `components/Header/`: sticky header with wordmark + divider, CSS-only text-roll hover on nav links, collapses to "DM" + Contact at <=960px (breakpoint precisely binary-searched against the live site, not the spec doc's claimed 768px)
- `components/Hero/`: avatar placeholder, mono intro line (wraps at 370px), opacity-stepped headline (44px mobile -> 80px at 960px -> 104px at 1440px+), divided meta row with available status, staggered fade/slide-up entry animation on load (CSS-only, respects `prefers-reduced-motion`)
- `components/Container.tsx`: shared max-width wrapper (1280px inner content) used by Header and Hero, ready for reuse in upcoming sections

## Notable corrections made after live-site verification

- Container inner content width corrected to 1280px (was 1072px)
- Hero flows naturally from the heading down (not stretched to fill the viewport)
- Removed an invented cursor-tracking pill hover background that doesn't exist on the reference site
- Nav breakpoint corrected to 960px via binary search
- Headline/avatar/wordmark sizing corrected to measured values at each breakpoint

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] Manually verified in the browser at mobile (390px), the 960px nav breakpoint boundary, desktop (1200px), and wide desktop (1440px)
- [x] Verified entry animation fires via `document.getAnimations()`
- [x] Verified no pill/background artifacts remain via DOM inspection

## Accessibility & performance

- [x] Meets WCAG 2.2 AA (focus-visible outline, semantic landmarks, skip-to-content link)
- [x] Respects `prefers-reduced-motion` for the entry animation and hover effects
- [x] No Core Web Vitals regressions — entry animation is CSS-only, nav has zero client JS (no state/hooks needed after removing the pill)
- [x] Page-level metadata already in place from the scaffold

🤖 Generated with [Claude Code](https://claude.com/claude-code)