### PR TITLE
fix: uppercase About CTAs, widen Work thumbnails, grayscale hover

### DIFF
--- a/components/About/About.tsx
+++ b/components/About/About.tsx
@@ -19,7 +19,7 @@ export function About() {
                 href="https://cal.com"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex items-center gap-1.5 rounded px-2 py-2 hover:underline"
+                className="flex items-center gap-1.5 rounded px-2 py-2 uppercase hover:underline hover:underline-offset-[3px]"
               >
                 Book a call
                 <ArrowUpRightIcon />
@@ -28,7 +28,7 @@ export function About() {
                 href="https://linkedin.com"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex items-center gap-1.5 rounded px-2 py-2 hover:underline"
+                className="flex items-center gap-1.5 rounded px-2 py-2 uppercase hover:underline hover:underline-offset-[3px]"
               >
                 LinkedIn
                 <ArrowUpRightIcon />

--- a/components/Work/WorkRow.tsx
+++ b/components/Work/WorkRow.tsx
@@ -34,8 +34,10 @@ export function WorkRow({ project, tone }: WorkRowProps) {
         </div>
         <div
           aria-hidden="true"
-          className="hidden aspect-[4/3] w-[180px] shrink-0 bg-surface-3 ring-1 ring-border-1 transition-transform duration-300 ease-out group-hover:scale-105 sm:block"
-        />
+          className="hidden aspect-[4/3] w-[302px] shrink-0 overflow-hidden bg-surface-3 ring-1 ring-border-1 md:block"
+        >
+          <div className="h-full w-full grayscale transition-[filter,transform] duration-300 ease-out group-hover:scale-105 group-hover:grayscale-0" />
+        </div>
         <span className="sr-only"> — View project</span>
       </Link>
     </div>


### PR DESCRIPTION
## Summary

Quick polish fixes to the already-merged About and Work sections.

## Type of change

- [x] fix — bug fix

## Changes

- About "Book a call" / "LinkedIn" links: uppercase (CSS `text-transform`, content stays mixed-case for the accessible name), 3px underline offset on hover
- Work row thumbnails: 180px -> 302px, breakpoint moved from `sm` (640px) to `md` (960px) since the wider frame was cramped at the old breakpoint
- Thumbnails now default to `grayscale(1)`, transitioning to full color on row hover alongside the existing scale-up — no visible difference yet on the flat-color placeholder, but the mechanism is ready for real images

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] Verified via computed styles: `text-transform: uppercase`, `text-underline-offset: 3px` (hover), thumbnail frame width 302px, `filter: grayscale(1)` at rest, `group-hover:grayscale-0` rule compiled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)